### PR TITLE
Fixed typo in custom field form

### DIFF
--- a/app/views/formats/_computed.html.erb
+++ b/app/views/formats/_computed.html.erb
@@ -8,7 +8,7 @@
   <%= label_tag l(:label_available_custom_fields) %>
   <%= select_tag '',
                  options_from_collection_for_select(cfs, 'id', 'name'),
-                 size: 5, multipe: true, id: 'select_for_formula' %>
+                 size: 5, multiple: true, id: 'select_for_formula' %>
 </p>
 <p>
   <%= label_tag l(:label_output_format) %>


### PR DESCRIPTION
Typo (multipe instead of multiple) was creating single selection drop-down instead of multi-selection list