### PR TITLE
Error handling

### DIFF
--- a/lib/patches/field_format.rb
+++ b/lib/patches/field_format.rb
@@ -107,6 +107,8 @@ module ComputedCustomFieldPlugin
           else
             value.to_s
         end
+      rescue
+        value.to_s
       end
 
       def validate_custom_field(custom_field)

--- a/lib/patches/klass.rb
+++ b/lib/patches/klass.rb
@@ -29,7 +29,7 @@ module ComputedCustomFieldPlugin
                        result.to_s
                    end
           self.custom_field_values = {value.custom_field.id => result}
-        rescue StandardError => e
+        rescue StandardError, SyntaxError => e
           self.errors.add :base, l(:error_while_formula_computing,
                                    custom_field_name: value.custom_field.name,
                                    message: e.message)


### PR DESCRIPTION
Error handling to prevent internal server errors on Issue opening

1. for problematic formatted_value issues
2. for deleted CustomFields that are used in ComputedCustomField formula

PS: the latter is incomplete as I found that self.errors.add did not lead to visual feedback to the user - but at least the internal server error is prevented