### PR TITLE
Fix pt-BR locale file name

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,5 +1,5 @@
 # Translated by Adriano Ceccarelli (https://github.com/aceccarelli)
-pt-br:
+pt-BR:
   label_computed: Calculado
   field_formula: Fórmula
   label_output_format: Formato de saída


### PR DESCRIPTION
The properly name for locale file is pt-BR not pt-br. Lower case
country code causes and error in Redmine that complete disable
translation for this language.