### PR TITLE
Alternative formula constructions

### DIFF
--- a/lib/patches/field_format.rb
+++ b/lib/patches/field_format.rb
@@ -145,6 +145,7 @@ module ComputedCustomFieldPlugin
           end
           object = eval(custom_field.type.sub('CustomField', '')).new
           def object.validate_formula(formula)
+            cfs = {}
             eval(formula)
           end
           object.validate_formula(formula)

--- a/lib/patches/klass.rb
+++ b/lib/patches/klass.rb
@@ -14,6 +14,11 @@ module ComputedCustomFieldPlugin
         cf_ids.each do |cf_id|
           formula.gsub!("%{cf_#{cf_id}}", custom_field_value(cf_id).to_s)
         end
+        cfs = {}
+        cf_ids = formula.scan(/cfs\[(\d+)\]/).flatten.map(&:to_i)
+        cf_ids.each do |cf_id|
+          cfs[cf_id] = custom_field_value(cf_id)
+        end
         begin
           result = eval(formula)
           result = case value.custom_field.output_format


### PR DESCRIPTION
Sometimes %{cf_id} construction don't works because we don't have
control over the field contents. A custom field can be empty or
even a value that lead us to invalid Ruby syntax.

The solution here just make available a local cfs array with custom
fields values. So, instead of %{cf_1} we can use cfs[1], it is very
useful when we have things like "%{cf_1} * %{cf_2}" that can be
translated to " * %{cf_2}" and trow a Ruby systax error, now we can
just user "cfs[1] * cfs[2]" or even "cfs[1].to_f * cfs[2].to_f"
without worry about empty values.

Note that old behavior still works and is used by default when we
double-click on an item in the list of available fields.